### PR TITLE
Add format input

### DIFF
--- a/lib/componentUtils.js
+++ b/lib/componentUtils.js
@@ -1,0 +1,7 @@
+exports.getComponent = function() {
+	if (this._parent) {
+		var keyFromIndex = Object.keys(_fvr[this._parent].structure)[this._index];
+		return _fvr[this._parent].structure[keyFromIndex];
+	}
+	return _fvr[this._index];
+};

--- a/lib/getters_and_setters.js
+++ b/lib/getters_and_setters.js
@@ -74,8 +74,8 @@ function set(val) {
 
 function passComponentsToSet(key) {
 	/*
-	gets a list of components to set the gpio of, checks that address is a structure
- 	or a directly addressed component, and then sets the gpio
+	gets a list of components to set, checks that address is a structure
+ 	or a directly addressed component, and then passes to set
 	*/
 	for (var i = 0; i < this._componentMatches.length; i++) {
 		setupFvr.call(this,i);
@@ -208,22 +208,25 @@ var _removeOn = function(watcher, cb) {
 		setupEvents.call(this, watcher, cb);
 		addCallbackToObject.call(this, cb);
 		if (_fvr[this._index].structure) {
-			structuredComponent(removeOn);
+			structuredComponent.call(this, removeOn);
 		} else {
 			removeOn.call(this);
 		}
 	}
 };
 
-function structuredComponent() {
-	for (key in _fvr[this._index].structure) {
-		this._index = this._index.structure[key];
-		if (!_fvr[this._index].initialized) {
-			return initializeComponent.call(this);
+function structuredComponent(method) {
+	var fvr = this;
+	console.log(Object.keys(_fvr[fvr._index].structure));
+	Object.keys(_fvr[fvr._index].structure).forEach(function(key) {
+
+		fvr._index = fvr._index.structure[key];
+		if (!_fvr[fvr._index].initialized) {
+			return initializeComponent.call(fvr, method);
 		}else {
-			return this._callback.call(this);
+			return fvr._callback.call(fvr, method);
 		}
-	}
+	});
 }
 
 function setupEvents(evt) {
@@ -250,7 +253,7 @@ function addOn(evt, cb) {
 		setupEvents.call(this, evt, cb);
 		addCallbackToObject.call(this, cb);
 		if (_fvr[this._index].structure) {
-			structuredComponent.call(onData);
+			structuredComponent.call(this, onData);
 		} else {
 			if (!_fvr[this._index].initialized) {
 				if (_fvr[this._index].interface === 'i2c') {

--- a/lib/getters_and_setters.js
+++ b/lib/getters_and_setters.js
@@ -80,15 +80,15 @@ function passComponentsToSet(x) {
 	*/
 	for (var i = 0; i < this._componentMatches.length; i++) {
 		setupFvr.call(this, i);
-		if (this._parent) {
-			this._valueToSet = valueToSet.call(this, x);
-			structuredComponent.call(this, set);
+		if (this._component.structure) {
+			this._componentValueToSet = x;
+			structuredComponent.call(this);
 		} else {
 			this._valueToSet = valueToSet.call(this, x);
 			if (!_fvr[this._index].initialized) {
-				return initializeComponent.call(this);
+				initializeComponent.call(this);
 			} else {
-				return this._method.call(this);
+				this._method.call(this);
 			}
 		}
 	}
@@ -122,19 +122,20 @@ var _set = function(x, key, cb) {
 		//if only class exists, use that to set value
 		var key = this.parsedQuery.class.join(',');
 	}
-	addCallbackToObject.call(this);
 	passComponentsToSet.call(this, x);
 };
 
 function getComponentAsObject() {
 	//the I/O is not directly addressed, but has an object of addresses.
-	for (key in _fvr[this._index].structure) {
-		this._index = this._index.structure[key];
-		if (!_fvr[this._index].initialized) {
-			initializeComponent.call(this);
+	var structureKeys = Object.keys(this._component.structure)
+	var fvr = this; 
+	structureKeys.forEach(function(key, idx){
+		fvr._index = idx;
+		if (!_fvr[fvr._parent].structure[fvr._index].initialized) {
+			return initializeComponent.call(fvr);
 		}
-		this._method.call(this);
-	}
+		fvr._method.call(fvr);
+	});
 }
 
 function getLinkIndex() {
@@ -147,11 +148,15 @@ function getLinkIndex() {
 }
 
 function setupFvr(i) {
-	if (this._index) return this; //the index has already been set, so probably a call to this from a callback
+	
 	var ci = this._componentMatches[i]; //component index
 	var cmp = _fvr[ci];
-	this._index = ci;
-	if (_fvr[this._index].structure) this._parent = ci;
+	this._component = cmp;
+	if (cmp.structure) {
+		this._parent = ci;
+	} else {
+		this._index = ci;
+	}
 	if (cmp.link) {
 		this._index = getLinkIndex.call(this);   //getting the index of the linked component
 		this._returnAs = _fvr[ci].type;
@@ -164,8 +169,8 @@ var _get = function(cb) {
 	this._method = get;
 	addCallbackToObject.call(this, cb);
 	for (var i = 0; i < this._componentMatches.length; i++) {
-		setupFvr.call(this,i);
-		if (_fvr[this._index].structure) { //not directly addressed, this is a group of  I/Os
+		setupFvr.call(this, i);
+		if (this._component.structure) { //not directly addressed, this is a group of  I/Os
 			getComponentAsObject.call(this);
 		} else {
 			if (!_fvr[this._index].initialized) {
@@ -228,17 +233,22 @@ var _removeOn = function(watcher, cb) {
 	}
 };
 
-function structuredComponent(method) {
-	var structureArray = Object.keys(_fvr[this._index].structure);
-	for (var key in _fvr[this._parent].structure) {
-		this._index = structureArray.indexOf(key);
-		var component = componentUtils.getComponent.call(this);
-		if (!component.initialized) {
-			return initializeComponent.call(this);
-		} else {
-			return this._method.call(this);
+function structuredComponent(){
+	var structureArray = Object.keys(this._component.structure);
+	var fvr = this;
+
+	structureArray.forEach(function(key, idx){
+		fvr._index = idx
+		var component = componentUtils.getComponent.call(fvr);
+		if (fvr._method.name === 'set') {
+			fvr._valueToSet = valueToSet.call(fvr, fvr._componentValueToSet);
 		}
-	}
+		if (!component.initialized) {
+			return initializeComponent.call(fvr);
+		} else {
+			return fvr._method.call(fvr);
+		}
+	});
 }
 
 function setupEvents(evt) {

--- a/lib/getters_and_setters.js
+++ b/lib/getters_and_setters.js
@@ -5,6 +5,7 @@ var i2c = require('./protocols/i2c');
 var spi = require('./protocols/spi');
 var EventEmitter = require('events').EventEmitter;
 var file = 'getters_and_setters.js';
+var componentUtils = require('./componentUtils');
 
 function initializeComponent() {
 	var fvr = this;
@@ -72,16 +73,18 @@ function set(val) {
 	}
 }
 
-function passComponentsToSet(key) {
+function passComponentsToSet(x) {
 	/*
 	gets a list of components to set, checks that address is a structure
  	or a directly addressed component, and then passes to set
 	*/
 	for (var i = 0; i < this._componentMatches.length; i++) {
-		setupFvr.call(this,i);
-		if (_fvr[this._index].structure) {
+		setupFvr.call(this, i);
+		if (this._parent) {
+			this._valueToSet = valueToSet.call(this, x);
 			structuredComponent.call(this, set);
 		} else {
+			this._valueToSet = valueToSet.call(this, x);
 			if (!_fvr[this._index].initialized) {
 				return initializeComponent.call(this);
 			} else {
@@ -89,6 +92,17 @@ function passComponentsToSet(key) {
 			}
 		}
 	}
+}
+
+function valueToSet(x) {
+	var component = componentUtils.getComponent.call(this);
+	if (component.formatInput) return component.formatInput.call(this, x);
+	
+	if (this._parent && _fvr[this._parent].formatInput) {
+		return _fvr[this._parent].formatInput.call(this, x);
+	}
+	
+	return x;
 }
 
 var _set = function(x, key, cb) {
@@ -108,9 +122,8 @@ var _set = function(x, key, cb) {
 		//if only class exists, use that to set value
 		var key = this.parsedQuery.class.join(',');
 	}
-	this._valueToSet = x;
 	addCallbackToObject.call(this);
-	passComponentsToSet.call(this, key);
+	passComponentsToSet.call(this, x);
 };
 
 function getComponentAsObject() {
@@ -138,7 +151,7 @@ function setupFvr(i) {
 	var ci = this._componentMatches[i]; //component index
 	var cmp = _fvr[ci];
 	this._index = ci;
-	this._parent = ci;
+	if (_fvr[this._index].structure) this._parent = ci;
 	if (cmp.link) {
 		this._index = getLinkIndex.call(this);   //getting the index of the linked component
 		this._returnAs = _fvr[ci].type;
@@ -216,17 +229,16 @@ var _removeOn = function(watcher, cb) {
 };
 
 function structuredComponent(method) {
-	var fvr = this;
-	console.log(Object.keys(_fvr[fvr._index].structure));
-	Object.keys(_fvr[fvr._index].structure).forEach(function(key) {
-
-		fvr._index = fvr._index.structure[key];
-		if (!_fvr[fvr._index].initialized) {
-			return initializeComponent.call(fvr, method);
-		}else {
-			return fvr._callback.call(fvr, method);
+	var structureArray = Object.keys(_fvr[this._index].structure);
+	for (var key in _fvr[this._parent].structure) {
+		this._index = structureArray.indexOf(key);
+		var component = componentUtils.getComponent.call(this);
+		if (!component.initialized) {
+			return initializeComponent.call(this);
+		} else {
+			return this._method.call(this);
 		}
-	});
+	}
 }
 
 function setupEvents(evt) {

--- a/lib/protocols/gpio.js
+++ b/lib/protocols/gpio.js
@@ -3,6 +3,7 @@ var gpio = process.env.DEVICE_MOCK_PATH ?
 	require('pi-pins');
 
 var file = 'protocols/gpio.js';
+var componentUtils = require('../componentUtils');
 
 var  directionObj = {
 	'led': 'out',
@@ -12,13 +13,17 @@ var  directionObj = {
 };
 
 function initialize() {
-	if (!_fvr[this._index].direction) {
-		_fvr[this._index].direction = _fvr[this._parent].direction ||
-			directionObj[_fvr[this._parent].type];
+	var component = componentUtils.getComponent.call(this);
+	if (!component.direction) {
+		if (_fvr[this._parent] && _fvr[this._parent].direction) {
+			component.direction = _fvr[this._parent].direction;
+		} else {
+			directionObj[component.type];
+		}
 	}
-	_fvr[this._index].gpio = gpio.connect(_fvr[this._index].address);
-	_fvr[this._index].gpio.mode(_fvr[this._index].direction);
-	_fvr[this._index].initialized = true;
+	component.gpio = gpio.connect(component.address);
+	component.gpio.mode(component.direction);
+	component.initialized = true;
 }
 
 function get() {
@@ -43,8 +48,9 @@ function checkGPIOVal() {
 }
 
 function set(val) {
-	val = checkGPIOVal.call(this,val);
-	_fvr[this._index].gpio.value(val);
+	val = checkGPIOVal.call(this, val);
+	var component = componentUtils.getComponent.call(this);
+	component.gpio.value(val);
 	if (this._callback) this._callback.call(this);
 }
 

--- a/tests/getters_setters.spec.js
+++ b/tests/getters_setters.spec.js
@@ -198,3 +198,23 @@ describe('formatOutput', function() {
 		});
 	});
 });
+
+describe('format input', function(){
+	it('should pass the set value through a format function', function() {
+		var x;
+		runs(function(){
+			$$('led#rgb').set({r:15, g: 0, b:250}, function(){
+				console.log(this);
+				x = this._valueToSet
+			});
+		});
+		
+		waitsFor(function(val){
+			x = val;
+		},1000);
+		
+		runs(function(){
+			expects(x).toBe(1);
+		});
+	});
+});

--- a/tests/getters_setters.spec.js
+++ b/tests/getters_setters.spec.js
@@ -201,20 +201,24 @@ describe('formatOutput', function() {
 
 describe('format input', function(){
 	it('should pass the set value through a format function', function() {
-		var x;
+		var x = {
+			'red' : null, 
+			'green' : null, 
+			'blue' : null
+		};
 		runs(function(){
 			$$('led#rgb').set({red:250, green:40, blue:8}, function(){
-				console.log('value to set', this._valueToSet);
-				x = this._valueToSet
+				
+				x[Object.keys(this._component.structure)[this._index]] = this._valueToSet
 			});
 		});
 		
 		waitsFor(function() {
-			return x;
+			return x.blue;
 		}, 1000);
 		
 		runs(function(){
-			expect(x).toBe(1);
+			expect(x.red).toBe(250);
 		});
 	});
 });

--- a/tests/getters_setters.spec.js
+++ b/tests/getters_setters.spec.js
@@ -203,18 +203,18 @@ describe('format input', function(){
 	it('should pass the set value through a format function', function() {
 		var x;
 		runs(function(){
-			$$('led#rgb').set({r:15, g: 0, b:250}, function(){
-				console.log(this);
+			$$('led#rgb').set({red:250, green:40, blue:8}, function(){
+				console.log('value to set', this._valueToSet);
 				x = this._valueToSet
 			});
 		});
 		
-		waitsFor(function(val){
-			x = val;
-		},1000);
+		waitsFor(function() {
+			return x;
+		}, 1000);
 		
 		runs(function(){
-			expects(x).toBe(1);
+			expect(x).toBe(1);
 		});
 	});
 });

--- a/tests/mocks/favorit.js
+++ b/tests/mocks/favorit.js
@@ -13,7 +13,11 @@ module.exports = {
 		{get: require('./component_methods')}]},
 		{type: 'led', name: 'rgb', structure: {
 			red: {address: 4}, green: {address: 5}, blue: {address: 6}
-		}, interface: 'gpio'},
+		}, interface: 'gpio', formatInput: function(x) {
+			if (typeof x === 'string') return x;
+			
+			return 1;
+		}},
 		{type: 'button', name: 'light',address: 7, interface: 'gpio'},
 		{type: 'link', name: 'rht03',address: 8, methods: [
 			{get: require('./linked_temp_humidity_mock')}], interface: 'gpio'},

--- a/tests/mocks/favorit.js
+++ b/tests/mocks/favorit.js
@@ -16,7 +16,7 @@ module.exports = {
 		}, interface: 'gpio', formatInput: function(x) {
 			if (typeof x === 'string') return x;
 			
-			return 1;
+			return x[Object.keys(this._component.structure)[this._index]];
 		}},
 		{type: 'button', name: 'light',address: 7, interface: 'gpio'},
 		{type: 'link', name: 'rht03',address: 8, methods: [


### PR DESCRIPTION
formatInput allows you to provide a function in the config file which will adjust the input value to the correct format at the time a component value is being set. 

For example, if an rgb led expects the input to be in a format of an array, and the value provided is an object containing the rgb values, the formatInput would translate/format the input to be an array and the output of the formatInput function would be set on the component.
